### PR TITLE
Add missing colon

### DIFF
--- a/update-firmware-bundles-json.py
+++ b/update-firmware-bundles-json.py
@@ -66,7 +66,7 @@ summary = []
 # loop through the hardware models
 import os
 for model in data:
-  if not "path" in data[model]
+  if not "path" in data[model]:
     continue
   display = data[model]['display']
   path = data[model]['path']


### PR DESCRIPTION
Hey, thanks for this great script. I found that one of the conditions misses a colon and therefore broke on my system. Here's the related fix.